### PR TITLE
feat: CSS-only responsive mobile navbar and toggle navbar-mobile-view

### DIFF
--- a/src/Root.jsx
+++ b/src/Root.jsx
@@ -1,10 +1,12 @@
 import MelonNavbar from './components/Navbar.jsx'
+import MobileNavigationBar from './components/MobileNavigationBar'
 import { Outlet } from 'react-router-dom'
 
 const Root = () => {
   return (
     <>
       <MelonNavbar />
+      <MobileNavigationBar />
       <Outlet />
     </>
   )

--- a/src/assets/css/MobileNavigationBar.css
+++ b/src/assets/css/MobileNavigationBar.css
@@ -1,0 +1,153 @@
+/* Show/hide navbars by screen size */
+
+
+.mobile-navbar {
+  width: 100%;
+  background: #ffecda;
+  border-bottom: 1px solid #f3e3d1;
+  position: relative;
+  z-index: 100;
+  
+}
+.mobile-navbar-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  height: 56px;
+  position: relative;
+}
+.mobile-navbar-logo {
+  height: 32px;
+  width: auto;
+  margin-right: 8px;
+}
+.mobile-navbar-icons {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+}
+.icon-btn {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 2px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  position: relative;
+}
+.cart-count {
+  position: absolute;
+  top: -6px;
+  right: -8px;
+  font-size: 12px;
+  color: #000;
+  background: transparent;
+}
+.mobile-navbar-toggle {
+  display: none;
+}
+.mobile-navbar-search {
+  display: none;
+  align-items: center;
+  background: #ffecda;
+  border-radius: 0;
+  width: 100%;
+  margin-left: 8px;
+  padding: 0 8px;
+  height: 40px;
+  border: 1px solid #bdbdbd;
+  position: absolute;
+  left: 48px;
+  right: 12px;
+  top: 8px;
+  z-index: 20;
+}
+.mobile-navbar-search .search-icon {
+  width: 20px;
+  margin-right: 8px;
+}
+.mobile-navbar-search input {
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  font-family: 'Montserrat', sans-serif;
+  color: #000;
+  outline: none;
+  flex: 1;
+}
+.close-btn {
+  margin-left: 8px;
+}
+.mobile-navbar-menu {
+  /* display: none; */
+  background: #fff;
+  width: 100vw;
+  position: absolute;
+  left: 0;
+  top: 56px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  padding: 0;
+  z-index: 10;
+  height: 100vh;
+}
+.mobile-navbar-link {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: 'Montserrat', sans-serif;
+  font-size: 1.35rem;
+  color: #222;
+  padding: 18px 20px 18px 16px;
+  border-bottom: 1px solid #f3e3d1;
+  cursor: pointer;
+}
+.mobile-navbar-link:last-child {
+  border-bottom: none;
+}
+.chevron {
+  width: 18px;
+  margin-left: 8px;
+}
+
+/* CSS toggling for search */
+#search-toggle:checked ~ label[for='search-toggle'] img,
+#search-toggle:checked ~ label[for='menu-toggle'],
+#search-toggle:checked ~ .mobile-navbar-icons,
+#search-toggle:checked ~ label[for='menu-toggle'] img {
+  display: none !important;
+}
+#search-toggle:checked ~ .mobile-navbar-search {
+  display: flex !important;
+}
+#search-toggle:checked ~ .mobile-navbar-menu {
+  display: none !important;
+}
+
+/* CSS toggling for menu */
+#menu-toggle:checked ~ .mobile-navbar-menu {
+  display: block;
+}
+#menu-toggle:checked ~ label[for='menu-toggle'] img {
+  filter: brightness(0.7);
+}
+#menu-toggle:checked ~ .mobile-navbar-search {
+  display: none !important;
+}
+#menu-toggle:checked ~ label[for='search-toggle'] img {
+  filter: none;
+}
+
+@media (min-width: 1200px) {
+  .mobile-navbar {
+    display: none;
+  }
+}
+
+
+@media (max-width: 1200px) {
+  .desktop-navbar {
+    display: none;
+  }
+}

--- a/src/components/MobileNavigationBar.jsx
+++ b/src/components/MobileNavigationBar.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import '../assets/css/MobileNavigationBar.css'
+
+const navLinks = [
+  'new arrivals',
+  'men',
+  'women',
+  'accessories',
+  'shoes',
+  'sale'
+]
+
+const MobileNavigationBar = () => {
+  const [openMenu, setOpenMenu] = useState(false)
+
+  return (
+    <nav className='mobile-navbar'>
+      <div className='mobile-navbar-top'>
+        <img
+          src='/public/melon-icon.svg'
+          alt='melon logo'
+          className='mobile-navbar-logo'
+        />
+        {/* Search toggle */}
+        <input
+          type='checkbox'
+          id='search-toggle'
+          className='mobile-navbar-toggle'
+          hidden
+        />
+        <label htmlFor='search-toggle' className='icon-btn'>
+          <img src='/public/search.svg' alt='search' />
+        </label>
+        {/* Menu toggle */}
+        <input
+          type='checkbox'
+          id='menu-toggle'
+          className='mobile-navbar-toggle'
+          // hidden
+        />
+        <label
+          htmlFor='menu-toggle'
+          className='icon-btn'
+          onClick={() => setOpenMenu(!openMenu)}
+        >
+          {openMenu ? (
+            <img src='/public/close.svg' alt='menu' />
+          ) : (
+            <img src='/public/menu.svg' alt='menu' />
+          )}
+        </label>
+        {/* Other icons (account, favorites, cart) */}
+        <div className='mobile-navbar-icons'>
+          <button className='icon-btn'>
+            <img src='/public/account.svg' alt='account' />
+          </button>
+          <button className='icon-btn'>
+            <img src='/public/favorite.svg' alt='favorites' />
+          </button>
+          <button className='icon-btn'>
+            <img src='/public/cart.svg' alt='cart' />
+            <span className='cart-count'>0</span>
+          </button>
+        </div>
+        {/* Search bar (CSS toggled) */}
+        <div className='mobile-navbar-search'>
+          <img src='/public/search.svg' alt='search' className='search-icon' />
+          <input type='text' placeholder='search' />
+          <label htmlFor='search-toggle' className='icon-btn close-btn'>
+            <img src='/public/close.svg' alt='close search' />
+          </label>
+        </div>
+      </div>
+      {/* Menu (CSS toggled) */}
+      {openMenu && (
+        <div className='mobile-navbar-menu'>
+          {navLinks.map((link) => (
+            <div className='mobile-navbar-link' key={link}>
+              {link}
+              <img
+                src='/public/chevron_forward.svg'
+                alt='>'
+                className='chevron'
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </nav>
+  )
+}
+
+export default MobileNavigationBar

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -82,6 +82,7 @@ const ThemeToggle = () => {
 
 const MelonNavbar = () => (
   <nav
+    className='desktop-navbar'
     style={{
       background: '#FFECDA',
       fontFamily: 'Montserrat, sans-serif',
@@ -104,7 +105,7 @@ const MelonNavbar = () => (
           <a
             href='/'
             className='d-flex align-items-center text-decoration-none'
-            style={{ minWidth: 160 }}
+            style={{ minWidth: 370 }}
           >
             <span
               className='fw-bold'
@@ -127,11 +128,7 @@ const MelonNavbar = () => (
           {/* Пошук по центру (absolute) */}
           <div
             style={{
-              position: 'absolute',
-              left: '50%',
-              top: '50%',
-              transform: 'translate(-50%, -50%)',
-              width: 420,
+              width: 370,
               maxWidth: '90%'
             }}
           >
@@ -162,8 +159,8 @@ const MelonNavbar = () => (
               <input
                 type='text'
                 placeholder='Find your next fit'
-                disabled
-                className='form-control form-control-lg ps-5 bg-transparent border-dark rounded'
+                
+                className='form-control form-control-lg ps-5 bg-transparent border-dark rounded no-focus'
                 style={{ height: 44, fontSize: 17, fontWeight: 500 }}
               />
             </div>


### PR DESCRIPTION
- MobileNavigationBar now switches via CSS media queries (desktop/mobile)
- Added burger menu with close icon, menu covers full viewport height on mobile
- All styles updated for correct mobile navbar behavior without JS-based responsiveness
- Desktop navbar hidden below 1200px, mobile navbar hidden at 1200px and above