### PR TITLE
refactor: use /browse/:id route for product detail everywhere

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ const router = createBrowserRouter(
     <Route path='/' element={<Root />}>
       <Route index element={<HomePage />} />
       <Route path='browse' element={<AllProducts />} />
-      <Route path='product/:id' element={<ProductPage />} />
+      <Route path='browse/:id' element={<ProductPage />} />
     </Route>
   )
 )

--- a/src/assets/css/ProductPage.css
+++ b/src/assets/css/ProductPage.css
@@ -1,0 +1,31 @@
+.product-page-flex {
+  display: flex;
+  gap: 56px;
+  max-width: 1200px;
+  width: 100%;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin: 0 24px;
+  flex-direction: row;
+}
+.product-page-image {
+  flex: 1 1 420px;
+  max-width: 520px;
+}
+.product-page-info {
+  flex: 1 1 340px;
+  max-width: 420px;
+}
+
+@media (max-width: 700px) {
+  .product-page-flex {
+    flex-direction: column;
+    gap: 32px;
+    margin: 0 8px;
+  }
+  .product-page-image,
+  .product-page-info {
+    max-width: 100% !important;
+    width: 100% !important;
+  }
+}

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -4,12 +4,12 @@ import '../assets/css/ProductCard.css'
 import { Link } from 'react-router-dom'
 
 const ProductCard = ({ product }) => {
-  const { id, image, title, price, isNew } = product
+  const { image, title, price, isNew, id } = product
   console.log(product)
 
   return (
     <Link
-      to={`/product/${id}`}
+      to={`/browse/${id}`}
       style={{
         textDecoration: 'none',
         color: 'inherit',

--- a/src/pages/ProductPage.jsx
+++ b/src/pages/ProductPage.jsx
@@ -1,6 +1,7 @@
 import { useParams } from 'react-router-dom'
 import products from '../../scripts/data/products.json'
 import { useState } from 'react'
+import '../assets/css/ProductPage.css'
 
 const SIZES = ['XS', 'S', 'M', 'L', 'XL']
 const COLORS = [
@@ -11,82 +12,116 @@ const COLORS = [
 
 const ProductPage = () => {
   const { id } = useParams()
-  const product = products.find(p => String(p.id) === String(id))
+  const product = products.find((p) => String(p.id) === String(id))
   const [selectedSize, setSelectedSize] = useState('M')
   const [selectedColor, setSelectedColor] = useState(COLORS[0].code)
 
-  if (!product) return <div style={{ padding: 48, fontFamily: 'Montserrat, sans-serif' }}>Product not found</div>
+  if (!product)
+    return (
+      <div style={{ padding: 48, fontFamily: 'Montserrat, sans-serif' }}>
+        Product not found
+      </div>
+    )
 
   return (
-    <div style={{
-      background: '#FAF9F8',
-      minHeight: '100vh',
-      fontFamily: 'Montserrat, sans-serif',
-      color: '#000',
-      padding: '40px 0',
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'flex-start'
-    }}>
-      <div style={{
+    <div
+      style={{
+        background: '#FAF9F8',
+        minHeight: '100vh',
+        fontFamily: 'Montserrat, sans-serif',
+        color: '#000',
+        padding: '40px 0',
         display: 'flex',
-        gap: 56,
-        maxWidth: 1200,
-        width: '100%',
-        alignItems: 'flex-start',
-        flexWrap: 'wrap',
-        margin: '0 24px'
-      }}>
+        justifyContent: 'center',
+        alignItems: 'flex-start'
+      }}
+    >
+      <div className='product-page-flex'>
         {/* Left: Main image and gallery */}
-        <div style={{ flex: '1 1 420px', maxWidth: 520 }}>
+        <div className='product-page-image'>
           <img
             src={product.image}
             alt={product.title}
-            style={{ width: '100%', height: 420, objectFit: 'cover', background: '#fff', borderRadius: 0 }}
+            style={{
+              width: '100%',
+              height: 420,
+              objectFit: 'cover',
+              background: '#fff',
+              borderRadius: 0
+            }}
           />
           {/* Gallery (dummy, same image) */}
           <div style={{ display: 'flex', gap: 24, marginTop: 24 }}>
-            {[0,1,2].map(i => (
+            {[0, 1, 2].map((i) => (
               <img
                 key={i}
                 src={product.image}
                 alt={product.title}
-                style={{ width: 140, height: 100, objectFit: 'cover', background: '#fff', borderRadius: 0 }}
+                style={{
+                  width: 140,
+                  height: 100,
+                  objectFit: 'cover',
+                  background: '#fff',
+                  borderRadius: 0
+                }}
               />
             ))}
           </div>
         </div>
         {/* Right: Info */}
-        <div style={{ flex: '1 1 340px', maxWidth: 420 }}>
+        <div className='product-page-info'>
           {product.isNew && (
-            <span style={{
-              background: '#FFECDA',
-              color: '#E13636',
-              fontWeight: 700,
-              fontSize: 12,
-              fontFamily: 'Montserrat, sans-serif',
-              letterSpacing: 0.2,
-              padding: '2px 8px',
-              marginBottom: 12,
-              display: 'inline-block',
-              borderRadius: 0
-            }}>new arrival</span>
+            <span
+              style={{
+                background: '#FFECDA',
+                color: '#E13636',
+                fontWeight: 700,
+                fontSize: 12,
+                fontFamily: 'Montserrat, sans-serif',
+                letterSpacing: 0.2,
+                padding: '2px 8px',
+                marginBottom: 12,
+                display: 'inline-block',
+                borderRadius: 0
+              }}
+            >
+              new arrival
+            </span>
           )}
-          <h2 style={{ fontWeight: 700, fontSize: 28, margin: '8px 0 0 0' }}>{product.title}</h2>
-          <div style={{ fontWeight: 600, fontSize: 20, margin: '8px 0 16px 0' }}>${product.price}</div>
-          <div style={{ fontSize: 15, fontWeight: 400, marginBottom: 18, lineHeight: 1.5 }}>
-            {product.description || 'Product description. You can do a lot of cool stuff while wearing this piece. People will like you more and you\'ll be more confident. Stop limiting yourself and buy this thing. You need it and you want it.'}
+          <h2 style={{ fontWeight: 700, fontSize: 28, margin: '8px 0 0 0' }}>
+            {product.title}
+          </h2>
+          <div
+            style={{ fontWeight: 600, fontSize: 20, margin: '8px 0 16px 0' }}
+          >
+            ${product.price}
           </div>
-          <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 8 }}>available colors:</div>
+          <div
+            style={{
+              fontSize: 15,
+              fontWeight: 400,
+              marginBottom: 18,
+              lineHeight: 1.5
+            }}
+          >
+            {product.description ||
+              "Product description. You can do a lot of cool stuff while wearing this piece. People will like you more and you'll be more confident. Stop limiting yourself and buy this thing. You need it and you want it."}
+          </div>
+          <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 8 }}>
+            available colors:
+          </div>
           <div style={{ display: 'flex', gap: 16, marginBottom: 18 }}>
-            {COLORS.map(color => (
+            {COLORS.map((color) => (
               <button
                 key={color.code}
                 style={{
                   width: 28,
                   height: 28,
                   background: color.code,
-                  border: selectedColor === color.code ? '2px solid #000' : '1px solid #888',
+                  border:
+                    selectedColor === color.code
+                      ? '2px solid #000'
+                      : '1px solid #888',
                   outline: 'none',
                   cursor: 'pointer',
                   margin: 0,
@@ -98,9 +133,11 @@ const ProductPage = () => {
               />
             ))}
           </div>
-          <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 8 }}>size:</div>
+          <div style={{ fontSize: 13, fontWeight: 500, marginBottom: 8 }}>
+            size:
+          </div>
           <div style={{ display: 'flex', gap: 8, marginBottom: 24 }}>
-            {SIZES.map(size => (
+            {SIZES.map((size) => (
               <button
                 key={size}
                 style={{
@@ -116,7 +153,9 @@ const ProductPage = () => {
                   borderRadius: 0
                 }}
                 onClick={() => setSelectedSize(size)}
-              >{size}</button>
+              >
+                {size}
+              </button>
             ))}
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: 16 }}>
@@ -133,7 +172,9 @@ const ProductPage = () => {
                 borderRadius: 0,
                 marginRight: 8
               }}
-            >Add to Cart</button>
+            >
+              Add to Cart
+            </button>
             <button
               style={{
                 background: '#FEEBEB',
@@ -149,7 +190,9 @@ const ProductPage = () => {
               }}
               aria-label='Add to favorites'
             >
-              <span role='img' aria-label='heart'>♡</span>
+              <span role='img' aria-label='heart'>
+                ♡
+              </span>
             </button>
           </div>
         </div>
@@ -158,4 +201,4 @@ const ProductPage = () => {
   )
 }
 
-export default ProductPage 
+export default ProductPage


### PR DESCRIPTION
- Removed all usage of /product/:id in favor of /browse/:id
- Product detail page now only accessible via /browse/:id
- Ensured all product cards and links point to /browse/:id